### PR TITLE
v0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 setuptools.setup(
     name='SRAscraper',
-    version='0.1.1',
+    version='0.1.2',
     author='Jake Lehle',
     author_email='jlehle@txbiomed.org',
     description='Snakmake pipeline to pull fastq sequencing files from the SRA database using their GSE accession identifiers from GEO.',

--- a/snakemake_wrapper/scripts/fastq_download_and_qc.py
+++ b/snakemake_wrapper/scripts/fastq_download_and_qc.py
@@ -41,6 +41,12 @@ for key in gse_dict.keys():
         print(f'Errors: {error}')
         print(f"\nRenamming {accession} fastqs")
         try:
+             os.rename(os.path.join(str(output_dir), 'fastq', str(key), str(accession), str(accession) + '_4.fastq.gz'),
+                       os.path.join(str(output_dir), 'fastq', str(key), str(accession), str(accession) + '_S1_L001_I2_001.fastq.gz'))
+             print(f"\nIndex {accession}_4.fastq.gz file found in GEO repo. Confirm dual indexing in project.")
+        except OSError as e:
+            print("Error renaming file:", e)
+        try:
              os.rename(os.path.join(str(output_dir), 'fastq', str(key), str(accession), str(accession) + '_3.fastq.gz'),
                        os.path.join(str(output_dir), 'fastq', str(key), str(accession), str(accession) + '_S1_L001_I1_001.fastq.gz'))
         except FileNotFoundError:


### PR DESCRIPTION
This update allows for more flexibility if paired sequencing files have dual indexes, which results in 4 fastqs reads being available for download, as is the case for custom single-cell experiments.